### PR TITLE
Replace wildcard imports with explicit imports

### DIFF
--- a/TTControlInstructions.glyphsPalette/Contents/Info.plist
+++ b/TTControlInstructions.glyphsPalette/Contents/Info.plist
@@ -13,9 +13,9 @@
 	<key>CFBundleName</key>
 	<string>ControlInstructions</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.8</string>
+	<string>1.0.9</string>
 	<key>CFBundleVersion</key>
-	<string>10</string>
+	<string>11</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright, Rainer Erich Scheichelbauer, 2018</string>
 	<key>NSPrincipalClass</key>

--- a/TTControlInstructions.glyphsPalette/Contents/Resources/plugin.py
+++ b/TTControlInstructions.glyphsPalette/Contents/Resources/plugin.py
@@ -13,8 +13,8 @@ from __future__ import division, print_function, unicode_literals
 ###########################################################################################################
 
 import objc
-from GlyphsApp import *
-from GlyphsApp.plugins import *
+from GlyphsApp import Glyphs, UPDATEINTERFACE
+from GlyphsApp.plugins import PalettePlugin
 
 class ControlInstructions (PalettePlugin):
 	dialogName = "com.mekkablue.ControlInstructionsPalette"


### PR DESCRIPTION
Follows the recent import-cleanup pattern applied across the Glyphs plug-in repos: replace wildcard imports with explicit ones.

### Changes
- `from GlyphsApp import *` → `from GlyphsApp import Glyphs, UPDATEINTERFACE`
- `from GlyphsApp.plugins import *` → `from GlyphsApp.plugins import PalettePlugin`
- Version bump: `CFBundleVersion` 10 → 11, `CFBundleShortVersionString` 1.0.8 → 1.0.9

`import objc` was already explicit. No behavioural change; only the imports are made explicit.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bs2JtfNiM4z5Duepf74nqX)_